### PR TITLE
Output GPU info to console

### DIFF
--- a/debug_js.go
+++ b/debug_js.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	webgl "github.com/seqsense/webgl-go"
+)
+
+func showDebugInfo(gl *webgl.WebGL) {
+	defer func() {
+		if r := recover(); r != nil {
+			println("Failed to get debug info")
+		}
+	}()
+
+	ri, ok := gl.GetExtension("WEBGL_debug_renderer_info")
+	if !ok {
+		println("GPU info: hidden by the browser privacy setting")
+		return
+	}
+	println("GPU:",
+		gl.GetParameter(ri.Get("UNMASKED_VENDOR_WEBGL").Int()).String(),
+		gl.GetParameter(ri.Get("UNMASKED_RENDERER_WEBGL").Int()).String(),
+	)
+	println("Max texture size:",
+		gl.GetParameter(gl.JS().Get("MAX_TEXTURE_SIZE").Int()).Int(),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/seqsense/pcgol v0.0.0-20210614050249-dd01f0753689
-	github.com/seqsense/webgl-go v0.0.0-20210810052327-b372299d4bcf
+	github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/seqsense/pcgol v0.0.0-20210614050249-dd01f0753689 h1:xXQ1Y77b8WgpvL3O/GAui01MUxTOJ2XPM1m3gB185hE=
 github.com/seqsense/pcgol v0.0.0-20210614050249-dd01f0753689/go.mod h1:w8LffJCFuzmJsqCRLWNB2SXOVHlEPtHBCHmlisG2w+0=
-github.com/seqsense/webgl-go v0.0.0-20210810052327-b372299d4bcf h1:J/I+16g9yK/PoiehUSoGeHZd7e+SLhR7y3Nfk+G9+i0=
-github.com/seqsense/webgl-go v0.0.0-20210810052327-b372299d4bcf/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
+github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73 h1:lhAUNNINdqjEi0DBrxdob3Dlw0wuMcyOayc7lBFdaoc=
+github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade h1:bafvQukPrIYwYWcft4rl3WpHo3qO0/voaAgnCwgdhi0=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade/go.mod h1:juNhYdla04C276MyU4zR0BA7t90ziLKPwkjDgddGYV0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main_js.go
+++ b/main_js.go
@@ -305,14 +305,7 @@ func (pe *pcdeditor) runImpl(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if ri, ok := gl.GetExtension("WEBGL_debug_renderer_info"); ok {
-		println("GPU info:",
-			gl.GetParameter(ri.Get("UNMASKED_VENDOR_WEBGL").Int()).String(),
-			gl.GetParameter(ri.Get("UNMASKED_RENDERER_WEBGL").Int()).String(),
-		)
-	} else {
-		println("GPU info: hidden by the browser privacy setting")
-	}
+	showDebugInfo(gl)
 
 	vs, err := initVertexShader(gl, vsSource)
 	if err != nil {

--- a/main_js.go
+++ b/main_js.go
@@ -305,6 +305,14 @@ func (pe *pcdeditor) runImpl(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if ri, ok := gl.GetExtension("WEBGL_debug_renderer_info"); ok {
+		println("GPU info:",
+			gl.GetParameter(ri.Get("UNMASKED_VENDOR_WEBGL").Int()).String(),
+			gl.GetParameter(ri.Get("UNMASKED_RENDERER_WEBGL").Int()).String(),
+		)
+	} else {
+		println("GPU info: hidden by the browser privacy setting")
+	}
 
 	vs, err := initVertexShader(gl, vsSource)
 	if err != nil {


### PR DESCRIPTION
To make it easy to investigate performance issue.
(In most case, it is caused by improper GPU setting of the browser and OS.)