### PR TITLE
Fix editor set pointcloud label

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -84,7 +84,7 @@ func (e *editor) SetPointCloud(pp *pc.PointCloud) error {
 		j.Incr()
 		i.Incr()
 		if iL != nil {
-			jL.SetUint32(jL.Uint32())
+			jL.SetUint32(iL.Uint32())
 			jL.Incr()
 			iL.Incr()
 		}

--- a/editor_test.go
+++ b/editor_test.go
@@ -8,52 +8,109 @@ import (
 	"github.com/seqsense/pcgol/pc"
 )
 
-func TestPassThrough(t *testing.T) {
-	pp := &pc.PointCloud{
-		PointCloudHeader: pc.PointCloudHeader{
+var vecs = []mat.Vec3{
+	{1, 2, 3},
+	{4, 5, 6},
+	{7, 8, 9},
+}
+
+var labels = []uint32{0, 1, 2}
+var intensities = []float32{0.5, 0.5, 0.5}
+
+func createPointCloud(t *testing.T, withIntensity bool) *pc.PointCloud {
+	var header pc.PointCloudHeader
+	if withIntensity {
+		header = pc.PointCloudHeader{
+			Fields: []string{"x", "y", "z", "intensity", "label"},
+			Size:   []int{4, 4, 4, 4, 4},
+			Type:   []string{"F", "F", "F", "F", "U"},
+			Count:  []int{1, 1, 1, 1, 1},
+			Width:  len(vecs),
+			Height: 1,
+		}
+	} else {
+		header = pc.PointCloudHeader{
 			Fields: []string{"x", "y", "z", "label"},
 			Size:   []int{4, 4, 4, 4},
 			Type:   []string{"F", "F", "F", "U"},
 			Count:  []int{1, 1, 1, 1},
-			Width:  3,
+			Width:  len(vecs),
 			Height: 1,
-		},
-		Points: 3,
+		}
 	}
-	pp.Data = make([]byte, 3*pp.Stride())
-	it, err := pp.Vec3Iterator()
+	pp := &pc.PointCloud{
+		PointCloudHeader: header,
+		Points:           len(vecs),
+	}
+	pp.Data = make([]byte, len(vecs)*pp.Stride())
+	vt, err := pp.Vec3Iterator()
 	if err != nil {
 		t.Fatal(err)
 	}
-	vecs := []mat.Vec3{
-		{1, 2, 3},
-		{4, 5, 6},
-		{7, 8, 9},
+	lt, err := pp.Uint32Iterator("label")
+	if err != nil {
+		t.Fatal(err)
 	}
-	it.SetVec3(vecs[0])
-	it.Incr()
-	it.SetVec3(vecs[1])
-	it.Incr()
-	it.SetVec3(vecs[2])
 
-	check := func(t *testing.T, out *pc.PointCloud) {
-		jt, err := out.Vec3Iterator()
+	for i := 0; i < len(vecs); i++ {
+		vt.SetVec3(vecs[i])
+		lt.SetUint32(labels[i])
+		vt.Incr()
+		lt.Incr()
+	}
+
+	if withIntensity {
+		it, err := pp.Float32Iterator("intensity")
 		if err != nil {
 			t.Fatal(err)
 		}
-		var outVec []mat.Vec3
-		for ; jt.IsValid(); jt.Incr() {
-			outVec = append(outVec, jt.Vec3())
-		}
-		expected := []mat.Vec3{
-			vecs[0],
-			vecs[2],
-		}
-
-		if !reflect.DeepEqual(expected, outVec) {
-			t.Errorf("Expected:\n%v\nGot:\n%v", expected, outVec)
+		for i := 0; i < len(intensities); i++ {
+			it.SetFloat32(intensities[i])
+			it.Incr()
 		}
 	}
+
+	return pp
+}
+
+func check(t *testing.T, out *pc.PointCloud, indices []int) {
+	vt, err := out.Vec3Iterator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lt, err := out.Uint32Iterator("label")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var expectedVec []mat.Vec3
+	var expectedLabel []uint32
+	for _, i := range indices {
+		expectedVec = append(expectedVec, vecs[i])
+		expectedLabel = append(expectedLabel, labels[i])
+	}
+
+	var outVec []mat.Vec3
+	for ; vt.IsValid(); vt.Incr() {
+		outVec = append(outVec, vt.Vec3())
+	}
+	if !reflect.DeepEqual(expectedVec, outVec) {
+		t.Errorf("Expected:\n%v\nGot:\n%v", expectedVec, outVec)
+	}
+
+	var outLabel []uint32
+	for ; lt.IsValid(); lt.Incr() {
+		outLabel = append(outLabel, lt.Uint32())
+	}
+	if !reflect.DeepEqual(expectedLabel, outLabel) {
+		t.Errorf("Expected:\n%v\nGot:\n%v", expectedLabel, outLabel)
+	}
+}
+
+func TestPassThrough(t *testing.T) {
+	pp := createPointCloud(t, false)
+
+	indices := []int{0, 2}
 	t.Run("ByVec", func(t *testing.T) {
 		out, err := passThrough(pp, func(i int, v mat.Vec3) bool {
 			if !v.Equal(vecs[i]) {
@@ -64,7 +121,7 @@ func TestPassThrough(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		check(t, out)
+		check(t, out, indices)
 	})
 	t.Run("ByMask", func(t *testing.T) {
 		sel := []uint32{0x10, 0x111, 0x11}
@@ -72,6 +129,24 @@ func TestPassThrough(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		check(t, out)
+		check(t, out, indices)
 	})
+}
+
+func TestSetPointCloud(t *testing.T) {
+	e := newEditor()
+
+	pps := []*pc.PointCloud{
+		createPointCloud(t, false),
+		createPointCloud(t, true),
+	}
+
+	indices := []int{0, 1, 2}
+	for _, pp := range pps {
+		if err := e.SetPointCloud(pp); err != nil {
+			t.Fatal(err)
+		}
+
+		check(t, e.pp, indices)
+	}
 }

--- a/editor_test.go
+++ b/editor_test.go
@@ -135,18 +135,16 @@ func TestPassThrough(t *testing.T) {
 
 func TestSetPointCloud(t *testing.T) {
 	e := newEditor()
-
 	pps := []*pc.PointCloud{
 		createPointCloud(t, false),
 		createPointCloud(t, true),
 	}
-
 	indices := []int{0, 1, 2}
+
 	for _, pp := range pps {
 		if err := e.SetPointCloud(pp); err != nil {
 			t.Fatal(err)
 		}
-
 		check(t, e.pp, indices)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/seqsense/pcdeditor
 go 1.16
 
 require (
-	github.com/seqsense/pcgol v0.0.0-20210926093440-914b84acc37b
+	github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967
 	github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/seqsense/pcgol v0.0.0-20210926093440-914b84acc37b h1:kxB9lpOyEqOPug7CCGLPcLwnb4uNKPdpgt2A7231UzY=
-github.com/seqsense/pcgol v0.0.0-20210926093440-914b84acc37b/go.mod h1:w8LffJCFuzmJsqCRLWNB2SXOVHlEPtHBCHmlisG2w+0=
+github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967 h1:UxTnlWkpxnMMpt/3PTShAO81r4pahdVmiwuag1qPTbg=
+github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967/go.mod h1:w8LffJCFuzmJsqCRLWNB2SXOVHlEPtHBCHmlisG2w+0=
 github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73 h1:lhAUNNINdqjEi0DBrxdob3Dlw0wuMcyOayc7lBFdaoc=
 github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade h1:bafvQukPrIYwYWcft4rl3WpHo3qO0/voaAgnCwgdhi0=


### PR DESCRIPTION
This PR addresses an issue with this editor `SetPointCloud` method where the label data was basically dropped due to the use of the wrong iterator. I added some tests that should exhibit the problem in `master` and get fixed with this PR. Note that `pcgol` needed to be updated to fix an issue with the iterators (https://github.com/seqsense/pcgol/pull/11).