### PR TITLE
Fix logger and show shader compilation log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967
-	github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73
+	github.com/seqsense/webgl-go v0.0.0-20211008022630-3c11d0d975fd
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967 h1:UxTnlWkpxnMMpt/3PTShAO81r4pahdVmiwuag1qPTbg=
 github.com/seqsense/pcgol v0.0.0-20211008005617-af4acebc0967/go.mod h1:w8LffJCFuzmJsqCRLWNB2SXOVHlEPtHBCHmlisG2w+0=
-github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73 h1:lhAUNNINdqjEi0DBrxdob3Dlw0wuMcyOayc7lBFdaoc=
-github.com/seqsense/webgl-go v0.0.0-20210812015006-a4655d333f73/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
+github.com/seqsense/webgl-go v0.0.0-20211008022630-3c11d0d975fd h1:shKnpuNl99MZ+LKIRLLAKn1+7VOfAVohM/Km/kS1geM=
+github.com/seqsense/webgl-go v0.0.0-20211008022630-3c11d0d975fd/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade h1:bafvQukPrIYwYWcft4rl3WpHo3qO0/voaAgnCwgdhi0=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade/go.mod h1:juNhYdla04C276MyU4zR0BA7t90ziLKPwkjDgddGYV0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -24,7 +24,7 @@ class PCDEditor {
 
     const log = qsRaw(this.opts.logId)
     this.logger = (msg) => {
-      if (msg.toString !== undefined) {
+      if (msg !== undefined && msg.toString !== undefined) {
         log.innerHTML = `${msg.toString().replace(/\n/g, '<br/>')}<br/>${
           log.innerHTML
         }`

--- a/shader_js.go
+++ b/shader_js.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"syscall/js"
 
 	webgl "github.com/seqsense/webgl-go"
@@ -17,7 +18,8 @@ func initVertexShader(gl *webgl.WebGL, src string) (webgl.Shader, error) {
 		if gl.IsContextLost() {
 			return webgl.Shader(js.Null()), errContextLost
 		}
-		return webgl.Shader(js.Null()), errors.New("compile failed (VERTEX_SHADER)")
+		compilationLog := gl.GetShaderInfoLog(s)
+		return webgl.Shader(js.Null()), fmt.Errorf("compile failed (VERTEX_SHADER) %v", compilationLog)
 	}
 	return s, nil
 }
@@ -30,7 +32,8 @@ func initFragmentShader(gl *webgl.WebGL, src string) (webgl.Shader, error) {
 		if gl.IsContextLost() {
 			return webgl.Shader(js.Null()), errContextLost
 		}
-		return webgl.Shader(js.Null()), errors.New("compile failed (FRAGMENT_SHADER)")
+		compilationLog := gl.GetShaderInfoLog(s)
+		return webgl.Shader(js.Null()), fmt.Errorf("compile failed (FRAGMENT_SHADER) %v", compilationLog)
 	}
 	return s, nil
 }


### PR DESCRIPTION
This PR fixes a minor issue with the editor logger that I ran into when playing around with the shader. When the shader cannot be compiled the following error will occur:

![image](https://user-images.githubusercontent.com/66578286/136505137-dd2177d6-8bdd-4869-9eb5-9abf46812a84.png)

As this PR is related to shader compilation error, I updated `webgl-go` to the latest version including https://github.com/seqsense/webgl-go/pull/11 and use `getShaderInfoLog` to show the shader compilation log on error.