### PR TITLE
Reduce default select range in orthographic view

### DIFF
--- a/command.go
+++ b/command.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultResolution             = 0.05
 	defaultSelectRangePerspective = 0.05
-	defaultSelectRangeOrtho       = 500.0
+	defaultSelectRangeOrtho       = 0.5
 	defaultMapAlpha               = 0.3
 	defaultZMin                   = -5.0
 	defaultZMax                   = 5.0


### PR DESCRIPTION
This PR simply reduces the default selection range when using the orthographic view. Here is the difference in video:

- With `master`: the selection box is so large that it is hard to resize or move around.

https://user-images.githubusercontent.com/66578286/138433171-53e44f03-30ea-47c2-ba0c-e0ec6d7e9e7d.mp4

- With this branch: the selection box has a more manageable size.

https://user-images.githubusercontent.com/66578286/138433295-0637af03-cb4f-4f27-891d-8b499fb73562.mp4
