### PR TITLE
Fix panic on zero points AddSurface

### DIFF
--- a/command.go
+++ b/command.go
@@ -504,6 +504,11 @@ func (c *commandContext) AddSurface(resolution float32) bool {
 
 	w := int(l0 / resolution)
 	h := int(l1 / resolution)
+
+	if w*h == 0 {
+		return true
+	}
+
 	pcNew := &pc.PointCloud{
 		PointCloudHeader: c.editor.pp.PointCloudHeader.Clone(),
 		Points:           w * h,

--- a/command_test.go
+++ b/command_test.go
@@ -285,3 +285,34 @@ func TestBaseFileter(t *testing.T) {
 		}, c.baseFilterByMask(false))
 	})
 }
+
+func TestAddSurface(t *testing.T) {
+	var selectRange float32 = 1.0
+	t.Run("NotSelected", func(t *testing.T) {
+		c := &commandContext{
+			selected: []mat.Vec3{
+				{0, 0, 0},
+				{0.1, 0, 0},
+			},
+			selectRange: &selectRange,
+		}
+		c.updateRect()
+		if ok := c.AddSurface(0.11); ok {
+			t.Fatal("AddSurface must success (but do nothing) if surface has zero points")
+		}
+	})
+	t.Run("ZeroPoints", func(t *testing.T) {
+		c := &commandContext{
+			selected: []mat.Vec3{
+				{0, 0, 0},
+				{0.1, 0, 0},
+				{0.1, 0.1, 0},
+			},
+			selectRange: &selectRange,
+		}
+		c.updateRect()
+		if ok := c.AddSurface(0.11); !ok {
+			t.Fatal("AddSurface must fail if region is not selected")
+		}
+	})
+}


### PR DESCRIPTION
```
13:34:12.195 /home/runner/work/pcdeditor/pcdeditor/main_js.go:508: main.(*pcdeditor).runImpl.func1 wasm_exec.js:50:14
13:34:12.196 /opt/hostedtoolcache/go/1.15.15/x64/src/runtime/panic.go:975: runtime.gopanic wasm_exec.js:50:14
13:34:12.196 /opt/hostedtoolcache/go/1.15.15/x64/src/runtime/panic.go:88: runtime.goPanicIndex wasm_exec.js:50:14
13:34:12.196 /home/runner/go/pkg/mod/github.com/seqsense/pcgol@v0.0.0-20211021090621-124e020a7ac3/pc/internal/float/float.go:11: github.com/seqsense/pcgol/pc/internal/float.ByteSliceAsFloat32Slice wasm_exec.js:50:14
13:34:12.196 /home/runner/go/pkg/mod/github.com/seqsense/pcgol@v0.0.0-20211021090621-124e020a7ac3/pc/pointcloud.go:97: github.com/seqsense/pcgol/pc.(*PointCloud).Float32Iterator wasm_exec.js:50:14
13:34:12.196 /home/runner/go/pkg/mod/github.com/seqsense/pcgol@v0.0.0-20211021090621-124e020a7ac3/pc/pointcloud.go:154: github.com/seqsense/pcgol/pc.(*PointCloud).Vec3Iterator wasm_exec.js:50:14
13:34:12.196 /home/runner/work/pcdeditor/pcdeditor/command.go:512: main.(*commandContext).AddSurface wasm_exec.js:50:14
13:34:12.196 /home/runner/work/pcdeditor/pcdeditor/main_js.go:1182: main.(*pcdeditor).runImpl wasm_exec.js:50:14
13:34:12.197 /home/runner/work/pcdeditor/pcdeditor/main_js.go:334: main.(*pcdeditor).Run wasm_exec.js:50:14
13:34:12.197 /opt/hostedtoolcache/go/1.15.15/x64/src/runtime/asm_wasm.s:428: runtime.goexit
```