### PR TITLE
Upload release asset by gh command

### DIFF
--- a/.github/workflows/license-collect.yml
+++ b/.github/workflows/license-collect.yml
@@ -34,11 +34,6 @@ jobs:
           done
           tar czf licenses.tar.gz ./licenses
       - name: Upload
-        uses: actions/upload-release-asset@v1
+        run: gh release upload ${{ github.event.release.tag_name }} licenses.tar.gz --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./licenses.tar.gz
-          asset_name: licenses.tar.gz
-          asset_content_type: application/gzip


### PR DESCRIPTION
actions/upload-release-asset is deprecated