### PR TITLE
Render label range

### DIFF
--- a/command.go
+++ b/command.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/seqsense/pcgol/mat"
 	"github.com/seqsense/pcgol/pc"
@@ -92,6 +93,8 @@ type commandContext struct {
 	segmentationDistance, segmentationRange float32
 
 	labelSegmentationRange, labelSegmentationSearchDistance float32
+
+	renderLabelMin, renderLabelMax uint32
 }
 
 func newCommandContext(pcdio pcdIO, mapio mapIO) *commandContext {
@@ -128,6 +131,8 @@ func (c *commandContext) Reset() {
 	c.segmentationRange = defaultSegmentationRange
 	c.labelSegmentationRange = defaultLabelSegmentationRange
 	c.labelSegmentationSearchDistance = defaultLabelSegmentationSearchDistance
+	c.renderLabelMin = 1
+	c.renderLabelMax = math.MaxUint32
 }
 
 func (c *commandContext) SelectMask() []uint32 {
@@ -184,6 +189,19 @@ func (c *commandContext) SetSegmentationParam(dist, r float32) error {
 		return errors.New("invalid segmentation param (R/D must be 1-256)")
 	}
 	c.segmentationDistance, c.segmentationRange = dist, r
+	return nil
+}
+
+func (c *commandContext) RenderLabelRange() (uint32, uint32) {
+	return c.renderLabelMin, c.renderLabelMax
+}
+
+func (c *commandContext) SetRenderLabelRange(min, max uint32) error {
+	if min > max {
+		return errors.New("invalid view label range param (max must be > min)")
+	}
+	c.renderLabelMin = min
+	c.renderLabelMax = max
 	return nil
 }
 

--- a/command.go
+++ b/command.go
@@ -198,7 +198,7 @@ func (c *commandContext) RenderLabelRange() (uint32, uint32) {
 
 func (c *commandContext) SetRenderLabelRange(min, max uint32) error {
 	if min > max {
-		return errors.New("invalid view label range param (max must be > min)")
+		return errors.New("invalid view label range param (max must be >= min)")
 	}
 	c.renderLabelMin = min
 	c.renderLabelMax = max

--- a/console.go
+++ b/console.go
@@ -339,6 +339,17 @@ var consoleCommands = map[string]func(c *console, updateSel updateSelectionFn, a
 			return nil, errArgumentNumber
 		}
 	},
+	"render_label_range": func(c *console, updateSel updateSelectionFn, args []float32) ([][]float32, error) {
+		switch len(args) {
+		case 0:
+			p0, p1 := c.cmd.RenderLabelRange()
+			return [][]float32{{float32(p0), float32(p1)}}, nil
+		case 2:
+			return nil, c.cmd.SetRenderLabelRange(uint32(args[0]), uint32(args[1]))
+		default:
+			return nil, errArgumentNumber
+		}
+	},
 }
 
 func (c *console) Run(line string, updateSel updateSelectionFn) ([][]float32, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/seqsense/pcgol v0.0.0-20220307140345-c4571d2ad780
-	github.com/seqsense/webgl-go v0.0.0-20211025051825-587860160885
+	github.com/seqsense/webgl-go v0.0.0-20220627023352-ef32d2a96714
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/seqsense/pcgol v0.0.0-20220307140345-c4571d2ad780 h1:k3q/Ye+xPJaZyZxXP/ZWjn0rZN/Yaeq14Zk/HpqugLY=
 github.com/seqsense/pcgol v0.0.0-20220307140345-c4571d2ad780/go.mod h1:w8LffJCFuzmJsqCRLWNB2SXOVHlEPtHBCHmlisG2w+0=
-github.com/seqsense/webgl-go v0.0.0-20211025051825-587860160885 h1:tjajt0Oe54nqqbOOY8U3RYGa/UgKV0gQYZiSzDnhqIY=
-github.com/seqsense/webgl-go v0.0.0-20211025051825-587860160885/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
+github.com/seqsense/webgl-go v0.0.0-20220627023352-ef32d2a96714 h1:+ZanXmP454yTdAEnqOCueMzm1i1FTvr8KamUvb+9kwA=
+github.com/seqsense/webgl-go v0.0.0-20220627023352-ef32d2a96714/go.mod h1:0maLEllOLyHaTnNFVivXfh1zXII/kSrvwY8F2sVCu7s=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade h1:bafvQukPrIYwYWcft4rl3WpHo3qO0/voaAgnCwgdhi0=
 github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade/go.mod h1:juNhYdla04C276MyU4zR0BA7t90ziLKPwkjDgddGYV0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main_js.go
+++ b/main_js.go
@@ -425,6 +425,8 @@ func (pe *pcdeditor) runImpl(ctx context.Context) error {
 	uZRangeLocation := gl.GetUniformLocation(program, "uZRange")
 	uPointSizeBase := gl.GetUniformLocation(program, "uPointSizeBase")
 	uUseSelectMask := gl.GetUniformLocation(program, "uUseSelectMask")
+	uMinLabel := gl.GetUniformLocation(program, "uMinLabel")
+	uMaxLabel := gl.GetUniformLocation(program, "uMaxLabel")
 
 	uProjectionMatrixLocationSub := gl.GetUniformLocation(programSub, "uProjectionMatrix")
 	uModelViewMatrixLocationSub := gl.GetUniformLocation(programSub, "uModelViewMatrix")
@@ -720,6 +722,10 @@ func (pe *pcdeditor) runImpl(ctx context.Context) error {
 				case selectModeMask:
 					gl.Uniform1i(uUseSelectMask, 1)
 				}
+
+				renderLabelMin, renderLabelMax := pe.cmd.RenderLabelRange()
+				gl.Uniform1ui(uMinLabel, renderLabelMin)
+				gl.Uniform1ui(uMaxLabel, renderLabelMax)
 
 				gl.BindBuffer(gl.ARRAY_BUFFER, posBuf)
 				gl.VertexAttribPointer(aVertexPosition, 3, gl.FLOAT, false, pp.Stride(), 0)

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -169,10 +169,10 @@ class PCDEditor {
             pcdeditor.command(`render_label_range ${min} ${max}`).catch(this.logger)
           }
         }
-        minLabelInput.oninput = (e) => onRenderLabelRangeChange()
-        minLabelInput.onchange = (e) => onRenderLabelRangeChange()
-        maxLabelInput.oninput = (e) => onRenderLabelRangeChange()
-        maxLabelInput.onchange = (e) => onRenderLabelRangeChange()
+        minLabelInput.oninput = () => onRenderLabelRangeChange()
+        minLabelInput.onchange = () => onRenderLabelRangeChange()
+        maxLabelInput.oninput = () => onRenderLabelRangeChange()
+        maxLabelInput.onchange = () => onRenderLabelRangeChange()
         onRenderLabelRangeChange()
 
 

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -132,6 +132,8 @@ class PCDEditor {
         const fovIncButton = this.qs('#fovInc')
         const fovDecButton = this.qs('#fovDec')
         const pointSizeInput = this.qs('#pointSize')
+        const minLabelInput = this.qs('#minLabel')
+        const maxLabelInput = this.qs('#maxLabel')
 
         const projectionMode = (target) => {
           if (target.checked) {
@@ -159,6 +161,20 @@ class PCDEditor {
           pcdeditor.command('fov -1').catch(this.logger)
         fovIncButton.onclick = () =>
           pcdeditor.command('fov 1').catch(this.logger)
+
+        const onRenderLabelRangeChange = () => {
+          const min = minLabelInput.value.trim()
+          const max = maxLabelInput.value.trim()
+          if (min.length > 0 && max.length > 0) {
+            pcdeditor.command(`render_label_range ${min} ${max}`).catch(this.logger)
+          }
+        }
+        minLabelInput.oninput = (e) => onRenderLabelRangeChange()
+        minLabelInput.onchange = (e) => onRenderLabelRangeChange()
+        maxLabelInput.oninput = (e) => onRenderLabelRangeChange()
+        maxLabelInput.onchange = (e) => onRenderLabelRangeChange()
+        onRenderLabelRangeChange()
+
 
         this.qs('#top').onclick = async () => {
           try {
@@ -666,6 +682,31 @@ class PCDEditor {
           <path d="M 30 20 L 50 100 L 70 20 Q 50 0 30 20 z" />
         </svg>
       </button>
+    </div>
+    <hr />
+    <div class="${id('foldMenuElem')}">
+      <label class="${id('inputLabel')}">Render label range</label>
+      <div class="${id('foldMenuElem')}">
+        <label
+          for="${id('minLabel')}"
+          class="${id('inputLabelShort')}"
+        >Min</label>
+        <input id="${id('minLabel')}"
+          type="number" min="1" value="1"
+          style="width: 3em; text-align: center;"
+        />
+      </div>
+      <div class="${id('foldMenuElem')}">
+        <label
+          for="${id('maxLabel')}"
+          class="${id('inputLabelShort')}"
+        >Max</label>
+        <input
+          id="${id('maxLabel')}"
+          type="number" min="1" value="1000"
+          style="width: 3em; text-align: center;"
+        />
+      </div>
     </div>
   </div>
 </span>

--- a/shader_source.go
+++ b/shader_source.go
@@ -12,6 +12,8 @@ const vsSource = `#version 300 es
 	uniform float uZRange;
 	uniform float uPointSizeBase;
 	uniform int uUseSelectMask;
+	uniform uint uMinLabel;
+	uniform uint uMaxLabel;
 	vec4 viewPosition;
 	vec4 selectPosition;
 	vec4 cropPosition;
@@ -85,7 +87,7 @@ const vsSource = `#version 300 es
 			}
 		}
 
-		if (aVertexLabel >= 1u) {
+		if (aVertexLabel >= uMinLabel && aVertexLabel <= uMaxLabel) {
 			vColor = label2color(int(aVertexLabel));
 		} else {
 			c = (aVertexPosition[2] - uZMin) / uZRange;


### PR DESCRIPTION
This PR adds a command and the corresponding UI menu to be able to render only a specific range of labels: the points outside of the specified range will be rendered as unlabeled points. Note that the data itself is not modified. Here is a video example:

https://user-images.githubusercontent.com/66578286/175859356-1d9ae514-1d7a-46f0-92d3-57915ccbef36.mp4

 