### PR TITLE
Add back missing buttons

### DIFF
--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -808,6 +808,7 @@ class PCDEditor {
       />
       <button id="${id('insertSubPcd')}">Select file</button>
     </div>
+    <hr/>
     <div class="${id('foldMenuElem')}">
       <label class="${id('inputLabel')}">Clipboard</label>
       <button id="${id('clipboardCopy')}">Copy</button>

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -793,6 +793,22 @@ class PCDEditor {
     </div>
     <hr/>
     <div class="${id('foldMenuElem')}">
+      <button id="${id('delete')}">Delete</button>
+    </div>
+    <hr/>
+    <div class="${id('foldMenuElem')}">
+      <label
+        class="${id('inputLabelShort')}"
+      >Insert pcd</label>
+      <input
+        id="${id('insertSubPcdFile')}"
+        type="file"
+        accept=".pcd"
+        style="display: none;"
+      />
+      <button id="${id('insertSubPcd')}">Select file</button>
+    </div>
+    <div class="${id('foldMenuElem')}">
       <label class="${id('inputLabel')}">Clipboard</label>
       <button id="${id('clipboardCopy')}">Copy</button>
       <button id="${id('clipboardPaste')}">Paste</button>


### PR DESCRIPTION
Some buttons were mistakenly removed in https://github.com/seqsense/pcdeditor/pull/154/files#diff-5acd5ded52accca9bc96beeace510d7cf6d77ed3be89a1a2c4e98416980b68c9L796-L811

- `master`
![master](https://user-images.githubusercontent.com/66578286/182786811-bde45a11-3dfa-43cb-af8e-39bcb0e0239c.png)

- `PR`
![pr](https://user-images.githubusercontent.com/66578286/182786864-13403620-dc52-4603-be2e-479bccc8f6a3.png)

