### PR TITLE
Fix global is not defined

### DIFF
--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -344,14 +344,14 @@ class PCDEditor {
           setupControls(this.pcdeditor)
           resolve()
         }
-        const go = new global.Go()
+        const go = new globalThis.Go()
         const { instance } = await WebAssembly.instantiateStreaming(
           fetch(this.opts.wasmPath, { cache: 'no-cache' }),
           go.importObject,
         )
         go.run(instance)
       }
-      if (typeof global === 'undefined' || typeof global.Go === 'undefined') {
+      if (typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined') {
         const script = document.createElement('script')
         script.onload = loadWasm
         script.src = this.opts.wasmExecPath
@@ -417,7 +417,7 @@ class PCDEditor {
           return resp.blob()
         })
         .then((yamlBlob) => {
-          const img = new global.Image()
+          const img = new globalThis.Image()
           img.onload = async () => {
             await this.pcdeditor.import2D(yamlBlob, img)
             resolve()

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -360,7 +360,7 @@ class PCDEditor {
         go.run(instance)
       }
       if ((typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined') &&
-          (typeof global === 'undefined' || typeof global.Go === 'undefined') {
+          (typeof global === 'undefined' || typeof global.Go === 'undefined')) {
         const script = document.createElement('script')
         script.onload = loadWasm
         script.src = this.opts.wasmExecPath

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -344,7 +344,16 @@ class PCDEditor {
           setupControls(this.pcdeditor)
           resolve()
         }
-        const go = new globalThis.Go()
+        let go
+        if (typeof globalThis !== 'undefined' && typeof globalThis.Go !== 'undefined') {
+          go = new globalThis.Go()
+        } else if (typeof global !== 'undefined' && typeof global.Go !== 'undefined') {
+          go = new global.Go()
+        }
+        else {
+          this.logger("'Go' could not be defined from neither globalThis nor global")
+          return
+        }
         const { instance } = await WebAssembly.instantiateStreaming(
           fetch(this.opts.wasmPath, { cache: 'no-cache' }),
           go.importObject,

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -359,7 +359,8 @@ class PCDEditor {
         )
         go.run(instance)
       }
-      if (typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined') {
+      if (typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined'
+          || typeof global.Go === 'undefined') {
         const script = document.createElement('script')
         script.onload = loadWasm
         script.src = this.opts.wasmExecPath

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -349,8 +349,7 @@ class PCDEditor {
           go = new globalThis.Go()
         } else if (typeof global !== 'undefined' && typeof global.Go !== 'undefined') {
           go = new global.Go()
-        }
-        else {
+        } else {
           this.logger("'Go' could not be defined from neither globalThis nor global")
           return
         }

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -426,7 +426,7 @@ class PCDEditor {
           return resp.blob()
         })
         .then((yamlBlob) => {
-          const img = new globalThis.Image()
+          const img = new Image()
           img.onload = async () => {
             await this.pcdeditor.import2D(yamlBlob, img)
             resolve()

--- a/pcdeditor.js
+++ b/pcdeditor.js
@@ -359,8 +359,8 @@ class PCDEditor {
         )
         go.run(instance)
       }
-      if (typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined'
-          || typeof global.Go === 'undefined') {
+      if ((typeof globalThis === 'undefined' || typeof globalThis.Go === 'undefined') &&
+          (typeof global === 'undefined' || typeof global.Go === 'undefined') {
         const script = document.createElement('script')
         script.onload = loadWasm
         script.src = this.opts.wasmExecPath


### PR DESCRIPTION
I ran into the following error when trying to accessing `pcdeditor` at `http://localhost:8080/` after running `make`. Renaming `global` to `globalThis` seems to solve the issue.
 
![Screenshot from 2022-10-04 15-57-05](https://user-images.githubusercontent.com/66578286/193759264-c071c3e9-17dc-40a8-8b66-4ca487ff0257.png)


