### PR TITLE
Fix sampling ratio to make the 'stride' value valid in gl.VertexAttribIPointer calls

### DIFF
--- a/main_js.go
+++ b/main_js.go
@@ -716,13 +716,20 @@ L_MAIN:
 			samplingRatio := 1
 			if pe.vi.dragging() {
 				totalPoints := 0
+				maxStride := 4
 				if hasPointCloud && pp.Points > 0 {
 					totalPoints += pp.Points
+					maxStride = max(pp.Stride(), maxStride)
 				}
 				if hasSubPointCloud && ppSub.Points > 0 && selectMode == selectModeInsert {
 					totalPoints += ppSub.Points
+					maxStride = max(ppSub.Stride(), maxStride)
 				}
 				samplingRatio = 1 + totalPoints/pe.cmd.NumFastRenderPoints()
+				// make sure the stride used in gl.VertexAttribIPointer is <= 255
+				if samplingRatio*maxStride > 255 {
+					samplingRatio = int(255.0 / maxStride)
+				}
 			}
 
 			if hasPointCloud && pp.Points > 0 {


### PR DESCRIPTION
I ran into the following warning when setting `num_fast_render_points` to `1000000` with a point cloud containing about 24 millions points:
![image](https://github.com/user-attachments/assets/36426e38-a34b-4472-be9b-f1a3e9183166)
In this case, the point cloud completely disappears when moving the viewpoint. This PR makes sure `samplingRatio` is adjusted to prevent the `stride` value to be over `255` in `gl.VertexAttribIPointer` calls.

