### PR TITLE
Directly read blob contents without copying to memory

### DIFF
--- a/map_js.go
+++ b/map_js.go
@@ -15,12 +15,13 @@ func (*mapIOImpl) readMap(yamlBlob, img interface{}) (*occupancyGrid, mapImage, 
 	if err != nil {
 		return nil, nil, err
 	}
-	b, err := bj.Bytes()
+	r, err := bj.Reader()
 	if err != nil {
 		return nil, nil, err
 	}
+	dec := yaml.NewDecoder(r)
 	m := &occupancyGrid{}
-	if err := yaml.Unmarshal(b, m); err != nil {
+	if err := dec.Decode(m); err != nil {
 		return nil, nil, err
 	}
 	return m, mapImageImpl(img.(js.Value)), err

--- a/pcd_js.go
+++ b/pcd_js.go
@@ -14,11 +14,11 @@ func (*pcdIOImpl) importPCD(b interface{}) (*pc.PointCloud, error) {
 	if err != nil {
 		return nil, err
 	}
-	bs, err := bj.Bytes()
+	r, err := bj.Reader()
 	if err != nil {
 		return nil, err
 	}
-	pp, err := pc.Unmarshal(bytes.NewReader(bs))
+	pp, err := pc.Unmarshal(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reduce peak memory usage during map load.

Previous implementation copied whole JS blob contents to memory and read via `bytes.Reader`.
New implementation adds a wrapper to directly read JS blob contents as `io.Reader`.

So, the peak memory usage during map load should be halved.