### PR TITLE
Fix surface points staying excluded after segment selection

### DIFF
--- a/command.go
+++ b/command.go
@@ -941,7 +941,7 @@ func (c *commandContext) SelectSegment(p mat.Vec3) {
 			if !coeff.IsIn(p, c.segmentationDistance) {
 				// Excude points only if the selected point is not on the surface.
 				surfIndice := coeff.Inliers(c.segmentationDistance)
-				surfRealIndice := make([]int, len(surfIndice))
+				surfRealIndice = make([]int, len(surfIndice))
 				for j, i := range surfIndice {
 					ri := vIndice[i]
 					c.selectMask[ri] |= selectBitmaskExclude


### PR DESCRIPTION
`surfRealIndice :=` shadowed the outer variable, so the loop clearing `selectBitmaskExclude` after segment selection never ran. Leftover exclude bits persisted in the select mask and silently dropped points from subsequent Alt+click / Ctrl+click segment selections.
